### PR TITLE
Use defaults if configuration file is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ bundle exec ruby koreapi.rb
 
 ### Config File
 
-By default, the server uses the settings in (./koreapi.default.properties) unless the file "/etc/koreapi.properties" exists.
+By default, the server uses the settings in [./koreapi.default.properties](./koreapi.default.properties) unless the file "/etc/koreapi.properties" exists.
 
-An example production configuration file is provided at (./koreapi.production.properties.example).
+An example production configuration file is provided at [./koreapi.default.properties](./koreapi.production.properties.example).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Start the service with.
 bundle exec ruby koreapi.rb
 ```
 
+### Config File
+
+By default, the server uses the settings in (./koreapi.default.properties) unless the file "/etc/koreapi.properties" exists.
+
+An example production configuration file is provided at (./koreapi.production.properties.example).
+
 ## Contributing
 
 1. Fork it!

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bundle exec ruby koreapi.rb
 
 By default, the server uses the settings in [./koreapi.default.properties](./koreapi.default.properties) unless the file "/etc/koreapi.properties" exists.
 
-An example production configuration file is provided at [./koreapi.default.properties](./koreapi.production.properties.example).
+An example production configuration file is provided at [./koreapi.production.properties.example](./koreapi.production.properties.example).
 
 ## Contributing
 

--- a/config.ru
+++ b/config.ru
@@ -1,16 +1,20 @@
 require 'rubygems'
 require 'bundler'
+require 'logger'
 
 Bundler.require
-
-require './koreapi'
 
 root_dir = File.dirname(__FILE__)
 
 $stdout.puts("Redirecting output to log/sinatra.log")
 FileUtils.mkdir_p 'log' unless File.exists?('log')
 log = File.new("log/sinatra.log", "a")
+
 $stdout.reopen(log)
 $stderr.reopen(log)
+$log = Logger.new(log)
+$log.level = Logger::ERROR
+
+require './koreapi'
 
 run KoreaPI

--- a/helpers/config_utils.rb
+++ b/helpers/config_utils.rb
@@ -7,14 +7,34 @@ module Sinatra
       CONFIG_FILE_PATH = "/etc/koreapi.properties"
 
       # -----------------------------------------------------------------------------------------------
-      # Returns the configuration file.  If the
+      # Tests to see if the config file passed exists and returns a valid config path.       #
+      #
+      # config_file_path: The file path of the configuration file
+      #
+      # returns: A valid path to a config file. If path passed does not exists, it returns the path
+      #   to the default configuration file included in the repo. Otherwise, it returns 
+      #   the path passed.
+      # -----------------------------------------------------------------------------------------------
+      def self.get_config_file_or_defaults(config_file_path)
+        if File.exists?(config_file_path)
+          config_file_path
+        else
+          $log.error("File path: " + config_file_path + " does not exist using defaults from "\
+                     "'./koreapi.default.properties'. If you are not a developer, you probably "\
+                     "do not want this to happen.")
+          "./koreapi.default.properties"
+        end
+      end
+
+      # -----------------------------------------------------------------------------------------------
+      # Returns the parsed configuration file hash.
       #
       # config_file_path: The file path of the configuration file
       # returns: ParseConfig instance which represents the configuration reflected at
       #   the property value.
       # -----------------------------------------------------------------------------------------------
       def self.get_config(config_file_path = CONFIG_FILE_PATH)
-        return ParseConfig.new(config_file_path)
+        return ParseConfig.new(get_config_file_or_defaults(config_file_path))
       end
 
 
@@ -26,7 +46,7 @@ module Sinatra
       # return the first non nil attribute.
       # -----------------------------------------------------------------------------------------------
       def self.get_first_attr(key, config_file_path = CONFIG_FILE_PATH)
-        return get_attrs(key, config_file_path).find{|s| !s.nil?}
+        return get_attrs(key, get_config_file_or_defaults(config_file_path)).find{|s| !s.nil?}
       end
 
       # -----------------------------------------------------------------------------------------------
@@ -38,7 +58,7 @@ module Sinatra
       # returns An array of all the attribute values.
       # -----------------------------------------------------------------------------------------------
       def self.get_attrs(key, config_file_path = CONFIG_FILE_PATH)
-        return get_config(config_file_path)[key].split(',')
+        return get_config(get_config_file_or_defaults(config_file_path))[key].split(',')
       end
 
     end

--- a/koreapi.default.properties
+++ b/koreapi.default.properties
@@ -1,0 +1,5 @@
+environment = development
+core.server.host = 127.0.0.1
+core.server.port = 8081
+metric-config.balboa.server.host = 127.0.0.1
+metric-config.balboa.server.port = 2012

--- a/koreapi.production.properties.example
+++ b/koreapi.production.properties.example
@@ -4,5 +4,7 @@ aws.region = [AWS Region]
 environment = [Deployment Environment]
 core.server.host = [Core Server Host in Environment]
 core.server.port = 8081 # Current Standard Port
-metric-config.balboa.server.host = [Balboa Load Balancer in Environment] # In current configuration, this is a load balancer so it does not hit the standard Balboa port, 2012.
-metric-config.balboa.server.port = 9898 # Current Port for Load Balancer
+# In current configuration, this is a load balancer so it does not hit the standard Balboa port, 2012
+metric-config.balboa.server.host = [Balboa Load Balancer in Environment] 
+# Current Port for Load Balancer
+metric-config.balboa.server.port = 9898 

--- a/koreapi.production.properties.example
+++ b/koreapi.production.properties.example
@@ -1,0 +1,8 @@
+aws.access_key_id = [Access Key ID]
+aws.secret_access_key = [Secret Access Key]
+aws.region = [AWS Region]
+environment = [Deployment Environment]
+core.server.host = [Core Server Host in Environment]
+core.server.port = 8081 # Current Standard Port
+metric-config.balboa.server.host = [Balboa Load Balancer in Environment] # In current configuration, this is a load balancer so it does not hit the standard Balboa port, 2012.
+metric-config.balboa.server.port = 9898 # Current Port for Load Balancer

--- a/koreapi.rb
+++ b/koreapi.rb
@@ -3,6 +3,12 @@ require 'json'
 require 'sinatra/base'
 require 'parseconfig'
 require 'tempfile'
+require 'logger'
+
+if $log.nil?
+  $log = Logger.new(STDOUT)
+  $log.level = Logger::DEBUG
+end
 
 require_relative 'helpers/param_utils'
 require_relative 'helpers/s3_utils'

--- a/lib/domains.rb
+++ b/lib/domains.rb
@@ -3,13 +3,11 @@ require 'sinatra/base'
 require_relative '../helpers/config_utils'
 
 class Domains
-
-  CORE_ADDRESS = Sinatra::KoreaPI::ConfigUtils.get_first_attr('core.server')
+  CORE_HOST = Sinatra::KoreaPI::ConfigUtils.get_first_attr('core.server.host')
+  CORE_PORT = Sinatra::KoreaPI::ConfigUtils.get_first_attr('core.server.port')
 
   def get_domains
-
-    addr_port = CORE_ADDRESS.split(":")
-    service = Net::HTTP.new(addr_port[0], addr_port[1])
+    service = Net::HTTP.new(CORE_HOST, CORE_PORT)
     url = '/domains?method=all'
     request = Net::HTTP::Get.new(url)
     result = service.request(request)

--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -10,11 +10,11 @@ end
 
 class Metrics
 
-  BALBOA_ADDRESS = Sinatra::KoreaPI::ConfigUtils.get_first_attr('metric-config.balboa.server')
-  BALBOA_PORT = 9898
+  BALBOA_HOST = Sinatra::KoreaPI::ConfigUtils.get_first_attr('metric-config.balboa.server.host')
+  BALBOA_PORT = Sinatra::KoreaPI::ConfigUtils.get_first_attr('metric-config.balboa.server.port')
 
   def initialize
-    @service = Net::HTTP.new(BALBOA_ADDRESS, BALBOA_PORT)
+    @service = Net::HTTP.new(BALBOA_HOST, BALBOA_PORT)
     @service.open_timeout=10000
     @service.read_timeout=30
   end


### PR DESCRIPTION
Added:
* Example of a correct local, developer configuration file
* Checks to see if the configuration existed before trying to read and falling back to defaults if absent
* Example production configuration file.  
* Documentation about config files in README